### PR TITLE
Updating readme to recommend latest Core Tools to avoid issue 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This sample shows simple ways to interact with Azure OpenAI & GPT-4 model to bui
 
 ### Pre-reqs
 1) [Python 3.8+](https://www.python.org/) 
-2) [Azure Functions Core Tools 4.0.6280 or higher](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools)
+2) [Azure Functions Core Tools 4.0.6610 or higher](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools)
 3) [Azurite](https://github.com/Azure/Azurite)
 
 The easiest way to install Azurite is using a Docker container or the support built into Visual Studio:

--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -26,6 +26,7 @@ module api '../core/host/functions-flexconsumption.bicep' = {
     tags: union(tags, { 'azd-service-name': serviceName })
     identityType: 'UserAssigned'
     identityId: identityId
+    identityClientId: identityClientId
     appSettings: union(appSettings,
       {
         AzureWebJobsStorage__clientId : identityClientId

--- a/infra/core/host/functions-flexconsumption.bicep
+++ b/infra/core/host/functions-flexconsumption.bicep
@@ -11,6 +11,8 @@ param virtualNetworkSubnetId string = ''
 param identityType string
 @description('User assigned identity name')
 param identityId string
+@description('User assigned identity client id')
+param identityClientId string
 
 // Runtime Properties
 @allowed([
@@ -71,8 +73,11 @@ resource functions 'Microsoft.Web/sites@2023-12-01' = {
     name: 'appsettings'
     properties: union(appSettings,
       {
-        AzureWebJobsStorage__accountName: stg.name
+        AzureWebJobsStorage__blobServiceUri: stg.properties.primaryEndpoints.blob
+        AzureWebJobsStorage__tableServiceUri: stg.properties.primaryEndpoints.table
+        AzureWebJobsStorage__queueServiceUri: stg.properties.primaryEndpoints.queue
         AzureWebJobsStorage__credential : 'managedidentity'
+        AzureWebJobsStorage__clientId : identityClientId
         APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
       })
   }


### PR DESCRIPTION
Updating readme to recommend latest Core Tools to avoid issue with Preview bundle not finding OpenAI triggers and bindings decorators

By updating to latest 4.0.6610 Azure Functions Core Tools version or higher, you will avoid this error:

```text
[2024-12-13T21:13:00.240Z] Worker failed to index functions
[2024-12-13T21:13:00.242Z] Result: Failure
Exception: AttributeError: 'FunctionApp' object has no attribute 'text_completion_input'
```

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
