### PR TITLE
Add local.settings.json for local development

### DIFF
--- a/local.settings.json
+++ b/local.settings.json
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AZURE_OPENAI_ENDPOINT": "https://cog-<unique-string>.openai.azure.com/",
+    "CHAT_MODEL_DEPLOYMENT_NAME": "chat",
+    "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `local.settings.json` with Azure OpenAI placeholder settings for local development. Requires `azd provision` first to create OpenAI resources, then update the endpoint. Uses Entra identity (secretless). Content matches the README instructions.

## What's included

`local.settings.json` with:
- `AzureWebJobsStorage: UseDevelopmentStorage=true` (Azurite emulator)
- `FUNCTIONS_WORKER_RUNTIME: python`
- `AZURE_OPENAI_ENDPOINT: https://cog-<unique-string>.openai.azure.com/`
- `CHAT_MODEL_DEPLOYMENT_NAME: chat`
- `AzureWebJobsFeatureFlags: EnableWorkerIndexing`
- `PYTHON_ISOLATE_WORKER_DEPENDENCIES: 1`

## Context

Tracked by Azure/azure-functions-templates#TRACKING_ISSUE — ensuring all manifest templates have `local.settings.json` for local development per review feedback.
